### PR TITLE
Get block verbose

### DIFF
--- a/src/bitcoin_rpc_api.rs
+++ b/src/bitcoin_rpc_api.rs
@@ -82,7 +82,10 @@ pub trait BitcoinRpcApi: Send + Sync {
     // TODO: getaddednodeinfo
     // TODO: getaddressesbyaccount
     // TODO: getbalance
-    // TODO: getbestblockhash
+
+    fn get_best_block_hash(&self) -> Result<Result<BlockHash, RpcError>, HTTPError> {
+        unimplemented!()
+    }
 
     fn get_block(&self, header_hash: &BlockHash) -> Result<Result<Block, RpcError>, HTTPError> {
         unimplemented!()

--- a/src/bitcoin_rpc_api.rs
+++ b/src/bitcoin_rpc_api.rs
@@ -99,7 +99,10 @@ pub trait BitcoinRpcApi: Send + Sync {
         unimplemented!()
     }
 
-    // TODO: getblockhash
+    fn get_block_hash(&self, height: u32) -> Result<Result<BlockHash, RpcError>, HTTPError> {
+        unimplemented!()
+    }
+
     // TODO: getblockheader
     // TODO: getblocktemplate
     // TODO: getchaintips

--- a/src/bitcoin_rpc_api.rs
+++ b/src/bitcoin_rpc_api.rs
@@ -87,7 +87,12 @@ pub trait BitcoinRpcApi: Send + Sync {
         unimplemented!()
     }
 
+    // TODO(evg): add verbosity param instead of separate methods?
     fn get_block(&self, header_hash: &BlockHash) -> Result<Result<Block, RpcError>, HTTPError> {
+        unimplemented!()
+    }
+
+    fn get_block_verbose(&self, header_hash: &BlockHash) -> Result<Result<VerboseBlock, RpcError>, HTTPError>  {
         unimplemented!()
     }
 

--- a/src/bitcoincore.rs
+++ b/src/bitcoincore.rs
@@ -164,6 +164,14 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         ))
     }
 
+    fn get_best_block_hash(&self) -> Result<Result<BlockHash, RpcError>, HTTPError> {
+        self.send(&RpcRequest::new0(
+            JsonRpcVersion::V1,
+            "42",
+            "getbestblockhash",
+        ))
+    }
+
     fn get_block(&self, header_hash: &BlockHash) -> Result<Result<Block, RpcError>, HTTPError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,

--- a/src/bitcoincore.rs
+++ b/src/bitcoincore.rs
@@ -193,6 +193,15 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         self.send(&RpcRequest::new0(JsonRpcVersion::V1, "42", "getblockcount"))
     }
 
+    fn get_block_hash(&self, height: u32) -> Result<Result<BlockHash, RpcError>, HTTPError> {
+        self.send(&RpcRequest::new1(
+            JsonRpcVersion::V1,
+            "42",
+            "getblockhash",
+            height,
+        ))
+    }
+
     fn get_new_address(&self) -> Result<Result<Address, RpcError>, HTTPError> {
         self.send(&RpcRequest::new2(
             JsonRpcVersion::V1,

--- a/src/bitcoincore.rs
+++ b/src/bitcoincore.rs
@@ -7,6 +7,8 @@ use std::fmt::Debug;
 use types::{Address, *};
 use BitcoinRpcApi;
 
+use serde_json;
+
 struct RetryConfig {
     max_retries: u32,
     interval: u64,
@@ -178,6 +180,25 @@ impl BitcoinRpcApi for BitcoinCoreClient {
             "42",
             "getblock",
             header_hash,
+        ))
+    }
+
+    fn get_block_verbose(&self, header_hash: &BlockHash) -> Result<Result<VerboseBlock, RpcError>, HTTPError>  {
+        let req = &RpcRequest::new2(
+            JsonRpcVersion::V1,
+            "42",
+            "getblock",
+            header_hash,
+            2
+        );
+        println!("{}", serde_json::to_string(req).unwrap());
+
+        self.send(&RpcRequest::new2(
+            JsonRpcVersion::V1,
+            "42",
+            "getblock",
+            header_hash,
+            2,
         ))
     }
 

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -19,6 +19,7 @@ impl From<BlockHeight> for u32 {
     }
 }
 
+// TODO(evg): avoid code duplicate
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct Block {
     pub hash: BlockHash,
@@ -32,6 +33,29 @@ pub struct Block {
     version_hex: String,
     merkleroot: String,
     pub tx: Vec<TransactionId>,
+    time: u64,
+    mediantime: u64,
+    nonce: u32,
+    bits: String,
+    difficulty: f64,
+    chainwork: String,
+    previousblockhash: Option<BlockHash>,
+    nextblockhash: Option<BlockHash>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct VerboseBlock {
+    pub hash: BlockHash,
+    confirmations: i32,
+    size: u32,
+    strippedsize: u32,
+    weight: u32,
+    height: u32,
+    version: u32,
+    #[serde(rename = "versionHex")]
+    version_hex: String,
+    merkleroot: String,
+    pub tx: Vec<VerboseRawTransaction>,
     time: u64,
     mediantime: u64,
     nonce: u32,

--- a/tests/rpc_calls.rs
+++ b/tests/rpc_calls.rs
@@ -94,6 +94,19 @@ fn getblock() {
 }
 
 #[test]
+fn getblockverbose() {
+    setup();
+
+    assert_successful_result(|client| {
+        let block_hash = BitcoinCoreTestClient::new(client).a_block_hash();
+
+        client.get_block_verbose(&block_hash)
+    })
+
+
+}
+
+#[test]
 fn validate_address() {
     setup();
 


### PR DESCRIPTION
I plan to implement retrieving blocks with txs but `cargo test getblockverbose` fails with

`thread 'getblockverbose' panicked at 'Failed to connect to node: Error { kind: Json(Error("missing field `blockhash`", line: 1, column: 1450)), url: None }', tests/common/assert.rs:35:28`

It produces probably valid request:
`{"jsonrpc":"1.0","id":"42","method":"getblock","params":["0e649b16b4871522ad99f29f334616efb50f6cd8dbac93befc9274ebdf4fb752",2]}`

Can you give me some hint?