### PR TITLE
Bump version 0.2 for next release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_rpc_client"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",


### PR DESCRIPTION
We have some breaking changes in the master so we need to bump the minor version for the next release.